### PR TITLE
fix SyntaxError: Unexpected identifier 'assert' for newer nodejs vers…

### DIFF
--- a/src/index.mjs
+++ b/src/index.mjs
@@ -18,7 +18,7 @@ console.debug('VERCEL_API_BASE:', VERCEL_API_BASE)
 console.debug('VERCEL_API_TOKEN:', VERCEL_API_TOKEN)
 console.debug('VERCEL_API_TOKEN:', VERCEL_TEAM)
 
-import pkg from '../package.json' assert { type: 'json' };
+import pkg from '../package.json' with { type: 'json' };
 
 const version = pkg.version
 


### PR DESCRIPTION
…ions

```bash
root@v32808:~# bunx vscdl --help
file:///tmp/bunx-0-vscdl@latest/node_modules/vscdl/src/index.mjs:21
import pkg from '../package.json' assert { type: 'json' };
                                  ^^^^^^

SyntaxError: Unexpected identifier 'assert'
    at compileSourceTextModule (node:internal/modules/esm/utils:338:16)
    at ModuleLoader.moduleStrategy (node:internal/modules/esm/translators:102:18)
    at #translate (node:internal/modules/esm/loader:468:12)
    at ModuleLoader.loadAndTranslate (node:internal/modules/esm/loader:515:27)
    at async ModuleJob._link (node:internal/modules/esm/module_job:115:19)

Node.js v22.14.0
```